### PR TITLE
Tests: distinguish between volume and mocked fs

### DIFF
--- a/tests/chat-logs/chat-logs.test.js
+++ b/tests/chat-logs/chat-logs.test.js
@@ -136,7 +136,7 @@ for (const file of testFiles) {
                 };
             };
             if (command == 'restart') {
-                test = simRequireIndex(test.fs, test.settings, new Date());
+                test = simRequireIndex(test.volume, test.settings, new Date());
                 test.chatbot_helper.say.mockImplementation(pushMessageWithStack);
             } else if (command == 'accuracy') {
                 accuracy = parseInt(rest);
@@ -167,7 +167,7 @@ for (const file of testFiles) {
                 test.random
                     .mockImplementationOnce(() => parseFloat(rest));
             } else if (command == 'fs-fail') {
-                jest.spyOn(test.fs, rest).mockImplementationOnce((a, b, c, d = undefined, e = undefined) => { throw new Error('fail on purpose in test'); });
+                jest.spyOn(test.fs, rest).mockImplementationOnce(() => { throw new Error('fail on purpose in test'); });
             } else if (command.startsWith('[') && command.endsWith(']')) {
                 await simSetTime(command.substring(1, command.length - 1), accuracy);
                 // const time = new Date();

--- a/tests/data-conversion/data-conversion.test.js
+++ b/tests/data-conversion/data-conversion.test.js
@@ -1,14 +1,9 @@
 'use strict';
 
 // imports
-const jestChance = require('jest-chance');
-const readline = require('readline');
-const { fail } = require('assert');
 const path = require('path');
 const fs = require('fs');
-const { Volume } = require('memfs');
-const { codeFrameColumns } = require('@babel/code-frame');
-const { simRequireIndex, simSetTime, simSetChatters, buildChatter, createMockFs, fetchMock, START_TIME, EMPTY_CHATTERS } = require('../simulation.js');
+const { simRequireIndex, simSetChatters, createMockVolume, fetchMock, START_TIME, EMPTY_CHATTERS } = require('../simulation.js');
 
 // fake timers
 jest.useFakeTimers();
@@ -29,18 +24,18 @@ beforeEach(() => {
     consoleErrorMock.mockClear();
 });
 
-const copy = (mockFs, realFs, mockFileName, realFileName) => {
+const copy = (volume, realFs, mockFileName, realFileName) => {
     if (realFs.existsSync(realFileName)) {
-        mockFs.writeFileSync(mockFileName, realFs.readFileSync(realFileName));
+        volume.fromJSON({ [mockFileName]: realFs.readFileSync(realFileName, 'utf-8') }, path.resolve('.'));
     }
 };
 
-const loadFileSystem = (testFolder) => {
-    let mockFs = createMockFs();
-    copy(mockFs, fs, './queso.save', path.resolve(__dirname, `data/${testFolder}/queso.save`));
-    copy(mockFs, fs, './userWaitTime.txt', path.resolve(__dirname, `data/${testFolder}/userWaitTime.txt`));
-    copy(mockFs, fs, './waitingUsers.txt', path.resolve(__dirname, `data/${testFolder}/waitingUsers.txt`));
-    return mockFs;
+const loadVolume = (testFolder) => {
+    let volume = createMockVolume();
+    copy(volume, fs, './queso.save', path.resolve(__dirname, `data/${testFolder}/queso.save`));
+    copy(volume, fs, './userWaitTime.txt', path.resolve(__dirname, `data/${testFolder}/userWaitTime.txt`));
+    copy(volume, fs, './waitingUsers.txt', path.resolve(__dirname, `data/${testFolder}/waitingUsers.txt`));
+    return volume;
 };
 
 const checkResult = (mockFs, realFs, testFolder) => {
@@ -51,10 +46,10 @@ const checkResult = (mockFs, realFs, testFolder) => {
 
 test('conversion-test-empty', () => {
     const test = 'test-empty';
-    let mockFs = loadFileSystem(test);
+    const volume = loadVolume(test);
     // empty file system
-    const index = simRequireIndex(mockFs);
-    mockFs = index.fs;
+    const index = simRequireIndex(volume);
+    const mockFs = index.fs;
     // should load without errors!
     expect(consoleWarnMock).toHaveBeenCalledTimes(0);
     expect(consoleErrorMock).toHaveBeenCalledTimes(0);
@@ -63,9 +58,9 @@ test('conversion-test-empty', () => {
 
 test('conversion-test-1', () => {
     const test = 'test-1';
-    let mockFs = loadFileSystem(test);
-    const index = simRequireIndex(mockFs);
-    mockFs = index.fs;
+    const volume = loadVolume(test);
+    const index = simRequireIndex(volume);
+    const mockFs = index.fs;
     // should load without errors, but a warning in the console
     expect(consoleWarnMock).toHaveBeenCalledWith("Assuming that usernames are lowercase Display Names, which does not work with Localized Display Names.");
     expect(consoleErrorMock).toHaveBeenCalledTimes(0);
@@ -78,9 +73,9 @@ test('conversion-test-1', () => {
 
 test('conversion-test-2', () => {
     const test = 'test-2';
-    let mockFs = loadFileSystem(test);
-    const index = simRequireIndex(mockFs);
-    mockFs = index.fs;
+    const volume = loadVolume(test);
+    const index = simRequireIndex(volume);
+    const mockFs = index.fs;
     // should load without errors and no exception was thrown
     expect(consoleWarnMock).toHaveBeenCalledTimes(0);
     expect(consoleErrorMock).toHaveBeenCalledTimes(0);
@@ -93,9 +88,9 @@ test('conversion-test-2', () => {
 
 test('conversion-test-3', () => {
     const test = 'test-3';
-    let mockFs = loadFileSystem(test);
-    const index = simRequireIndex(mockFs);
-    mockFs = index.fs;
+    const volume = loadVolume(test);
+    const index = simRequireIndex(volume);
+    const mockFs = index.fs;
     // should load without errors and no exception was thrown
     expect(consoleWarnMock).toHaveBeenCalledTimes(0);
     expect(consoleErrorMock).toHaveBeenCalledTimes(0);
@@ -108,9 +103,9 @@ test('conversion-test-3', () => {
 
 test('conversion-test-4', () => {
     const test = 'test-4';
-    let mockFs = loadFileSystem(test);
-    const index = simRequireIndex(mockFs);
-    mockFs = index.fs;
+    const volume = loadVolume(test);
+    const index = simRequireIndex(volume);
+    const mockFs = index.fs;
     // should load without errors and no exception was thrown
     expect(consoleWarnMock).toHaveBeenCalledTimes(0);
     expect(consoleErrorMock).toHaveBeenCalledTimes(0);
@@ -123,9 +118,9 @@ test('conversion-test-4', () => {
 
 test('conversion-test-5', () => {
     const test = 'test-5';
-    let mockFs = loadFileSystem(test);
-    const index = simRequireIndex(mockFs);
-    mockFs = index.fs;
+    const volume = loadVolume(test);
+    const index = simRequireIndex(volume);
+    const mockFs = index.fs;
     // should load without errors and no exception was thrown
     expect(consoleWarnMock).toHaveBeenCalledTimes(0);
     expect(consoleErrorMock).toHaveBeenCalledTimes(0);
@@ -138,11 +133,12 @@ test('conversion-test-5', () => {
 
 test('conversion-test-corrupt-1', () => {
     const test = 'test-corrupt-1';
-    let mockFs = loadFileSystem(test);
-    
+    const volume = loadVolume(test);
+    let mockFs;
+
     const index = () => {
         try {
-            simRequireIndex(mockFs);
+            simRequireIndex(volume);
         } catch (err) {
             mockFs = err.simIndex.fs;
             throw err;
@@ -156,11 +152,12 @@ test('conversion-test-corrupt-1', () => {
 
 test('conversion-test-corrupt-2', () => {
     const test = 'test-corrupt-2';
-    let mockFs = loadFileSystem(test);
+    const volume = loadVolume(test);
+    let mockFs;
     
     const index = () => {
         try {
-            simRequireIndex(mockFs);
+            simRequireIndex(volume);
         } catch (err) {
             mockFs = err.simIndex.fs;
             throw err;
@@ -176,11 +173,12 @@ test('conversion-test-corrupt-2', () => {
 
 test('conversion-test-corrupt-3', () => {
     const test = 'test-corrupt-3';
-    let mockFs = loadFileSystem(test);
+    const volume = loadVolume(test);
+    let mockFs;
     
     const index = () => {
         try {
-            simRequireIndex(mockFs);
+            simRequireIndex(volume);
         } catch (err) {
             mockFs = err.simIndex.fs;
             throw err;
@@ -196,11 +194,12 @@ test('conversion-test-corrupt-3', () => {
 
 test('conversion-test-corrupt-4', () => {
     const test = 'test-corrupt-4';
-    let mockFs = loadFileSystem(test);
+    const volume = loadVolume(test);
+    let mockFs;
     
     const index = () => {
         try {
-            simRequireIndex(mockFs);
+            simRequireIndex(volume);
         } catch (err) {
             mockFs = err.simIndex.fs;
             throw err;

--- a/tests/simulation.js
+++ b/tests/simulation.js
@@ -90,7 +90,7 @@ const createMockVolume = (settings = undefined) => {
  * @param {number | Date} mockTime 
  * @returns {index} {@link index} 
  */
-function simRequireIndex(volume = undefined, mockSettings = undefined, mockTime = undefined) {
+const simRequireIndex = (volume = undefined, mockSettings = undefined, mockTime = undefined) => {
     let fs;
     let settings;
     let chatbot;
@@ -164,7 +164,7 @@ function simRequireIndex(volume = undefined, mockSettings = undefined, mockTime 
             expect(chatbot.helper).toHaveBeenCalledTimes(1);
             chatbot_helper = chatbot.helper.mock.results[0].value;
 
-            expect(chatbot_helper.setup).toHaveBeenCalledTimes(1)
+            expect(chatbot_helper.setup).toHaveBeenCalledTimes(1);
             expect(chatbot_helper.connect).toHaveBeenCalledTimes(1);
             expect(chatbot_helper.setup).toHaveBeenCalledTimes(1);
             expect(chatbot_helper.say).toHaveBeenCalledTimes(0);
@@ -250,11 +250,11 @@ const simSetTime = async (time, accuracy = 0) => {
         // should not happen
         throw Error(`Time went backwards, from ${prevTime} to ${newTime} (${time})`);
     }
-}
+};
 
-const buildChatter = function (username, displayName, isSubscriber, isMod, isBroadcaster) {
+const buildChatter = (username, displayName, isSubscriber, isMod, isBroadcaster) => {
     return { username, displayName, isSubscriber, isMod, isBroadcaster };
-}
+};
 
 module.exports = {
     simRequireIndex,

--- a/tests/simulation.js
+++ b/tests/simulation.js
@@ -2,7 +2,7 @@
 
 // imports
 const jestChance = require('jest-chance');
-const { Volume } = require('memfs');
+const { Volume, createFsFromVolume } = require('memfs');
 const path = require('path');
 
 // constants
@@ -57,9 +57,12 @@ const simSetChatters = (newChatters) => {
     mockChatters = newChatters;
 };
 
-const createMockFs = () => {
+const createMockVolume = (settings = undefined) => {
     const volume = new Volume();
     volume.mkdirSync(path.resolve('.'), { recursive: true });
+    if (settings !== undefined) {
+        volume.fromJSON({'./settings.json': JSON.stringify(settings)}, path.resolve('.'));
+    }
     return volume;
 };
 
@@ -69,7 +72,8 @@ const createMockFs = () => {
 
 /**
  * @typedef index
- * @property {Volume} fs file system
+ * @property {Object} fs file system
+ * @property {Volume} volume mock volume
  * @property {settings} settings settings 
  * @property {Object} chatbot the chatbot mock
  * @property {Object} chatbot_helper the chatbot instance that `index.js` is using
@@ -86,7 +90,7 @@ const createMockFs = () => {
  * @param {number | Date} mockTime 
  * @returns {index} {@link index} 
  */
-function simRequireIndex(mockFs = undefined, mockSettings = undefined, mockTime = undefined) {
+function simRequireIndex(volume = undefined, mockSettings = undefined, mockTime = undefined) {
     let fs;
     let settings;
     let chatbot;
@@ -117,24 +121,27 @@ function simRequireIndex(mockFs = undefined, mockSettings = undefined, mockTime 
                     return chance.random();
                 });
 
-            // create virtual file system
-            if (mockFs === undefined) {
-                mockFs = createMockFs();
-            } else {
-                // copy files
-                const files = mockFs.toJSON();
-                mockFs = new Volume();
-                mockFs.fromJSON(files);
-            }
-            // setup virtual file system
-            jest.mock('fs', () => mockFs);
-            fs = require('fs');
-
-            // write settings.json file
+            // prepare settings
             if (mockSettings === undefined) {
                 mockSettings = DEFAULT_TEST_SETTINGS;
             }
-            mockFs.writeFileSync('./settings.json', JSON.stringify(mockSettings));
+
+            // create virtual file system
+            if (volume === undefined) {
+                volume = createMockVolume(mockSettings);
+            } else {
+                // copy files
+                const files = volume.toJSON();
+                volume = new Volume();
+                volume.fromJSON(files);
+                volume.fromJSON({'./settings.json': JSON.stringify(mockSettings)}, path.resolve('.'));
+            }
+
+            // setup virtual file system
+            const mockFs = createFsFromVolume(volume);
+            jest.mock('fs', () => mockFs);
+            fs = require('fs');
+
             // import settings
             settings = require('../settings.js');
 
@@ -170,6 +177,7 @@ function simRequireIndex(mockFs = undefined, mockSettings = undefined, mockTime 
     } catch (err) {
         err.simIndex = {
             fs,
+            volume,
             settings,
             chatbot,
             chatbot_helper,
@@ -182,6 +190,7 @@ function simRequireIndex(mockFs = undefined, mockSettings = undefined, mockTime 
 
     return {
         fs,
+        volume,
         settings,
         chatbot,
         chatbot_helper,
@@ -253,7 +262,7 @@ module.exports = {
     simSetTime,
     simSetChatters,
     buildChatter,
-    createMockFs,
+    createMockVolume,
     fetchMock: fetch,
     START_TIME,
     DEFAULT_TEST_SETTINGS,

--- a/tests/twitch.test.js
+++ b/tests/twitch.test.js
@@ -17,7 +17,7 @@ const defaultTestSettings = {
 };
 
 // mock variables
-var mockChatters = undefined;
+var mockChatters;
 
 // mocks
 jest.mock('node-fetch', () => jest.fn());
@@ -61,15 +61,9 @@ beforeEach(() => {
     jest.setSystemTime(new Date('2022-04-21T00:00:00Z'));
 });
 
-const build_chatter = function (username, displayName, isSubscriber, isMod, isBroadcaster) {
-    return {
-        username: username,
-        displayName: displayName,
-        isSubscriber: isSubscriber,
-        isMod: isMod,
-        isBroadcaster: isBroadcaster
-    }
-}
+const buildChatter = (username, displayName, isSubscriber, isMod, isBroadcaster) => {
+    return { username, displayName, isSubscriber, isMod, isBroadcaster };
+};
 
 test('online users', async () => {
     let twitch;
@@ -97,7 +91,7 @@ test('online users', async () => {
 
     jest.setSystemTime(new Date('2022-04-21T00:00:00Z'));
     // notice chatter
-    twitch.noticeChatter(build_chatter('furretwalkbot', 'FurretWalkBot', false, true, false));
+    twitch.noticeChatter(buildChatter('furretwalkbot', 'FurretWalkBot', false, true, false));
     await expect(twitch.getOnlineUsers(settings.channel)).resolves.toEqual(new Set(['liquidnya', 'helperblock', 'redzebra_', 'furretwalkbot']));
 
     // after 4 minutes still online!
@@ -112,7 +106,7 @@ test('online users', async () => {
     twitch.setToLurk('helperblock');
     await expect(twitch.getOnlineUsers(settings.channel)).resolves.toEqual(new Set(['liquidnya', 'redzebra_']));
     // even when they still chat, they are not online
-    twitch.noticeChatter(build_chatter('helperblock', 'helperblock', false, true, false));
+    twitch.noticeChatter(buildChatter('helperblock', 'helperblock', false, true, false));
     await expect(twitch.getOnlineUsers(settings.channel)).resolves.toEqual(new Set(['liquidnya', 'redzebra_']));
 
     // unlurk makes them online again!


### PR DESCRIPTION
Use `createFsFromVolume` from the `memfs` library to mock the file system correctly.
Also changes the code to distinguish between the mocked file system and the volume.
This will make sure that if code is using constants within the file system object in the future to work correctly.