### PR TITLE
Fix custom codes and fix restore

### DIFF
--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const persistence = require("./persistence.js");
 
 // patch fs to use the graceful-fs, to retry a file rename under windows
 persistence.patchGlobalFs();
-
+persistence.createDataDirectory();
 quesoqueue.load();
 
 var queue_open = settings.start_open;
@@ -443,9 +443,12 @@ async function HandleMessage(message, sender, respond) {
   } else if (settings.level_timeout && message == "!restart" && sender.isBroadcaster) {
     level_timer.restart();
     respond("Starting the clock over! CP Hype!");
-  } else if (message == "!restore" && sender.isBroadcaster) {
-    quesoqueue.load();
-    respond(level_list_message(quesoqueue.current(), await quesoqueue.list()));
+  } else if (message.startsWith("!persistence") && sender.isBroadcaster) {
+    const subCommand = get_remainder(message);
+    const response = await quesoqueue.persistenceManagement(subCommand);
+    console.log(subCommand);
+    console.log(response);
+    respond(`@${sender.displayName} ${response}`);
   } else if (message == "!clear" && sender.isBroadcaster) {
     quesoqueue.clear();
     respond("The queue has been cleared!");

--- a/index.js
+++ b/index.js
@@ -216,13 +216,7 @@ async function HandleMessage(message, sender, respond) {
     respond("The queue is now closed!");
   } else if (message.toLowerCase().startsWith("!add")) {
     if (queue_open || sender.isBroadcaster) {
-      let level_code = get_remainder(message.toUpperCase());
-      if (settings.custom_codes_enabled) {
-        let customCodesMap = persistence.loadCustomCodesSync();
-        if (customCodesMap.has(level_code)) {
-          level_code = customCodesMap.get(level_code);
-        }
-      }
+      let level_code = get_remainder(message);
       respond(
         quesoqueue.add(Level(level_code, sender.displayName, sender.username))
       );
@@ -241,13 +235,7 @@ async function HandleMessage(message, sender, respond) {
     message.startsWith("!change") ||
     message.startsWith("!swap")
   ) {
-    let level_code = get_remainder(message.toUpperCase());
-    if (settings.custom_codes_enabled) {
-      let customCodesMap = persistence.loadCustomCodesSync();
-      if (customCodesMap.has(level_code)){
-        level_code = customCodesMap.get(level_code);
-      }
-    }
+    let level_code = get_remainder(message);
     respond(quesoqueue.replace(sender.displayName, level_code));
   } else if (message == "!level" && sender.isBroadcaster) {
     let next_level;
@@ -464,7 +452,7 @@ async function HandleMessage(message, sender, respond) {
         respond(await quesoqueue.customCodeManagement(codeArguments));
       }
     } else {
-      respond(await quesoqueue.customCodes());
+      respond(quesoqueue.customCodes());
     }
   } else if (message == "!brb") {
     twitch.setToLurk(sender.username);

--- a/persistence.js
+++ b/persistence.js
@@ -287,12 +287,13 @@ const saveQueue = async (currentLevel, queue, waiting, callback = undefined) => 
 };
 
 const loadCustomCodesSync = () => {
-    return new Map(loadFileOrCreate(CUSTOM_CODES_FILENAME, () => saveCustomCodesSync(new Map()), 'Custom codes will not function.'));
+    const codeList = loadFileOrCreate(CUSTOM_CODES_FILENAME, () => saveCustomCodesSync([]), 'Custom codes will not function.');
+    return codeList;
 };
 
-const saveCustomCodesSync = (customCodesMap, errorMessage = undefined) => {
+const saveCustomCodesSync = (codeList, errorMessage = undefined) => {
     try {
-        writeFileAtomicSync(CUSTOM_CODES_FILENAME, JSON.stringify([...customCodesMap]));
+        writeFileAtomicSync(CUSTOM_CODES_FILENAME, JSON.stringify(codeList));
     } catch (err) {
         if (errorMessage !== undefined) {
             console.warn(errorMessage);

--- a/persistence.js
+++ b/persistence.js
@@ -265,11 +265,13 @@ const createSaveFileContent = (currentLevel, queue, waiting) => {
 const saveQueueSync = (currentLevel, queue, waiting) => {
     try {
         writeFileAtomicSync(FILENAME_V2.fileName, createSaveFileContent(currentLevel, queue, waiting));
+        return true;
     } catch (err) {
         console.error('%s could not be saved. The queue will keep running, but the state is not persisted and might be lost on restart.', FILENAME_V2.fileName, err);
         // ignore this error and keep going
         // hopefully this issue is gone on the next save
         // or maybe even solved by the user while the queue keeps running, e.g. not enough space on disk
+        return false;
     }
 };
 

--- a/persistence.js
+++ b/persistence.js
@@ -1,7 +1,8 @@
 const settings = require('./settings.js');
 const fs = require('fs');
+const gracefulFs = require("graceful-fs");
 const writeFileAtomic = require('write-file-atomic');
-const writeFileAtomicSync = require('write-file-atomic').sync;
+const writeFileAtomicSync = writeFileAtomic.sync;
 
 const FILENAME_V1 = { queso: './queso.save', userOnlineTime: './userOnlineTime.txt', userWaitTime: './userWaitTime.txt', waitingUsers: './waitingUsers.txt' };
 const FILENAME_V2 = { directory: './data', fileName: './data/queue.json' };
@@ -45,14 +46,18 @@ const CUSTOM_CODES_FILENAME = './customCodes.json';
 //     - waitTime: integer, the wait time in minutes
 //     - lastOnlineTime: string, ISO 8601 timestamp
 
+const patchGlobalFs = () => {
+    gracefulFs.gracefulify(fs);
+};
+
 const hasOwn = (object, property) => {
-    return Object.prototype.hasOwnProperty.call(object, property)
-}
+    return Object.prototype.hasOwnProperty.call(object, property);
+};
 
 const loadFileDefault = (fileName, newContent, errorMessage) => {
     if (fs.existsSync(fileName)) {
         try {
-            const fileContents = JSON.parse(fs.readFileSync(fileName));
+            const fileContents = JSON.parse(fs.readFileSync(fileName, { encoding: "utf8" }));
             console.log(`${fileName} has been successfully validated.`);
             return fileContents;
         } catch (err) {
@@ -70,7 +75,7 @@ const loadFileOrCreate = (fileName, createFunction, errorMessage) => {
             if (create) {
                 createFunction();
             }
-            const fileContents = JSON.parse(fs.readFileSync(fileName));
+            const fileContents = JSON.parse(fs.readFileSync(fileName, { encoding: "utf8" }));
             console.log('%s has been successfully%s validated.', fileName, create ? ' created and' : '');
             return fileContents;
         } catch (err) {
@@ -88,11 +93,11 @@ const loadFileOrCreate = (fileName, createFunction, errorMessage) => {
 const loadQueueV1 = () => {
     const cache_filename = FILENAME_V1.queso;
     const now = (new Date()).toISOString();
-    let levels = new Array();
-    let currentLevel = undefined;
+    let levels = [];
+    let currentLevel;
     // load levels
     if (fs.existsSync(cache_filename)) {
-        const raw_data = fs.readFileSync(cache_filename);
+        const raw_data = fs.readFileSync(cache_filename, { encoding: "utf8" });
         levels = JSON.parse(raw_data);
         const username_missing = level => !hasOwn(level, 'username');
         if (levels.some(username_missing)) {
@@ -181,7 +186,7 @@ const waitingFromObject = (waiting) => {
 
 const loadQueueV2 = () => {
     const fileName = FILENAME_V2.fileName;
-    const state = JSON.parse(fs.readFileSync(fileName));
+    const state = JSON.parse(fs.readFileSync(fileName, { encoding: "utf8" }));
     if (!hasOwn(state, 'version')) {
         throw new Error(`Queue save file ${fileName}: no version field.`);
     } else if (typeof state.version !== 'string') {
@@ -312,4 +317,5 @@ module.exports = {
     waitingFromObject,
     loadCustomCodesSync,
     saveCustomCodesSync,
+    patchGlobalFs,
 };

--- a/queue.js
+++ b/queue.js
@@ -590,14 +590,18 @@ const queue = {
     let [command, ...rest] = codeArguments.split(" ");
     if (command == "add" && rest.length == 2) {
       const [customName, realName] = rest;
+      const levelCode = extractValidCode(realName);
+      if (!levelCode.valid) {
+        return "That is an invalid level code.";
+      }
 
       if (customCodes.has(customName)) {
         const existingName = customCodes.getName(customName);
         return `The custom code ${existingName} already exists`;
       }
-      customCodes.set(customName, realName);
+      customCodes.set(customName, levelCode.code);
       save("An error occurred while trying to add your custom code.");
-      return `Your custom code ${customName} for ID ${realName} has been added.`;
+      return `Your custom code ${customName} for ID ${levelCode.code} has been added.`;
     } else if (command == "remove" && rest.length == 1) {
       const [customName] = rest;
       if (!customCodes.has(customName)) {

--- a/tests/chat-logs/chat-logs.test.js
+++ b/tests/chat-logs/chat-logs.test.js
@@ -157,6 +157,22 @@ for (const file of testFiles) {
                     error.message += errorMessage(position());
                     throw error;
                 }
+            } else if (command.startsWith('customCodes')) {
+                try {
+                    const memberIdx = command.indexOf('/');
+                    let jsonData = JSON.parse(test.fs.readFileSync(path.resolve(__dirname, '../../customCodes.json')));
+                    if (memberIdx != -1) {
+                        const member = command.substring(memberIdx + 1);
+                        jsonData = jsonData[member];
+                    }
+                    expect(jsonData).toEqual(JSON.parse(rest));
+                } catch (error) {
+                    error.message += errorMessage(position());
+                    throw error;
+                }
+            } else if (command.startsWith('save')) {
+                const fileName = command.substring(command.indexOf(':') + 1);
+                test.fs.writeFileSync(path.resolve(__dirname, '../..', fileName), rest);
             } else if (command == 'seed') {
                 const chance = jestChance.getChance(rest);
                 test.random

--- a/tests/chat-logs/logs/add.test.log
+++ b/tests/chat-logs/logs/add.test.log
@@ -60,3 +60,17 @@ settings {"username":"helperblock","password":"oauth:test","channel":"liquidnya"
 
 queue.json/currentLevel {"code":"NB0-1MD-SLG","submitter":"liquidnya","username":"liquidnya"}
 queue.json/queue [{"code":"MY2-H2M-DSG","submitter":"FurretWalkBot","username":"furretwalkbot"}]
+
+[02:19:13] ~%?liquidnya: !clear
+[02:19:14] @^helperblock: The queue has been cleared!
+
+# lowercase level codes work
+[02:24:35] ~%?liquidnya: !add nb0-1md-slg
+[02:24:35] @^helperblock: liquidnya, NB0-1MD-SLG has been added to the queue.
+
+[02:19:13] ~%?liquidnya: !clear
+[02:19:14] @^helperblock: The queue has been cleared!
+
+# lowercase level codes without dashes work
+[02:24:35] ~%?liquidnya: !add nb01mdslg
+[02:24:35] @^helperblock: liquidnya, NB0-1MD-SLG has been added to the queue.

--- a/tests/chat-logs/logs/custom-codes.test.log
+++ b/tests/chat-logs/logs/custom-codes.test.log
@@ -50,3 +50,11 @@ save:customCodes.json [["Test","NB0-1MD-SLG"],["OwO","BW2-G2R-CMG"]]
 
 [19:35:42] ~%?liquidnya: !add owo
 [19:35:42] @^helperblock: liquidnya, BW2-G2R-CMG has been added to the queue.
+
+# invalid level code
+[23:21:13] ~%?liquidnya: !customcode add invalid-syntax MD0-1MD-SLA
+[23:21:14] @^helperblock: That is an invalid level code.
+
+# this code is invalid because its checksum is invalid
+[23:21:21] ~%?liquidnya: !customcode add invalid-checksum MD0-2MD-SLG
+[23:21:22] @^helperblock: That is an invalid level code.

--- a/tests/chat-logs/logs/custom-codes.test.log
+++ b/tests/chat-logs/logs/custom-codes.test.log
@@ -1,5 +1,7 @@
 # "username" will decide which of the messages are from the bot
 settings {"username":"helperblock","password":"oauth:test","channel":"liquidnya","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5,"custom_codes_enabled":true}
+# restart to test with custom_codes_enabled set to true from the very beginning
+restart
 # chatters 
 chatters {"_links":{},"chatter_count":4,"chatters":{"broadcaster":["liquidnya"],"vips":[],"moderators":["furretwalkbot","streamelements"],"staff":[],"admins":[],"global_mods":[],"viewers":["viewerlevels"]}}
 # chatty chat log
@@ -7,11 +9,14 @@ chatters {"_links":{},"chatter_count":4,"chatters":{"broadcaster":["liquidnya"],
 # @ moderator
 # % subscriber
 
+# check that the custom codes file is initialized with []
+customCodes []
+
 [19:34:55] ~%?liquidnya: !customcode remove test
 [19:34:57] @^helperblock: The custom code test could not be found.
-[19:35:05] ~%?liquidnya: !customcode add test NB0-1MD-SLG
-[19:35:05] @^helperblock: Your custom code test for ID NB0-1MD-SLG has been added.
-[19:35:12] ~%?liquidnya: !add test
+[19:35:05] ~%?liquidnya: !customcode add Test NB0-1MD-SLG
+[19:35:05] @^helperblock: Your custom code Test for ID NB0-1MD-SLG has been added.
+[19:35:12] ~%?liquidnya: !add Test
 [19:35:12] @^helperblock: liquidnya, NB0-1MD-SLG has been added to the queue.
 
 # test if codes were persisted
@@ -19,7 +24,29 @@ restart
 
 [19:35:42] ~%?liquidnya: !add test
 [19:35:42] @^helperblock: liquidnya, NB0-1MD-SLG has been added to the queue.
+
+[13:01:34] ~%?liquidnya (Fae/Faer): !customcodes
+[13:01:34] @^helperblock (Any): The current custom codes are: Test.
+
+customCodes [["Test","NB0-1MD-SLG"]]
+
 [19:36:54] ~%?liquidnya: !customcode remove test
-[19:36:54] @^helperblock: The custom code test has been removed.
+[19:36:54] @^helperblock: The custom code Test for ID NB0-1MD-SLG has been removed.
+
+customCodes []
+
 [19:36:58] ~%?liquidnya: !add test
 [19:36:58] @^helperblock: liquidnya, that is an invalid level code.
+
+# reload codes from disk
+
+save:customCodes.json [["Test","NB0-1MD-SLG"],["OwO","BW2-G2R-CMG"]]
+
+[19:36:58] ~%?liquidnya: !customcode load
+[19:36:58] @^helperblock: Reloaded custom codes from disk.
+
+[19:35:42] ~%?liquidnya: !add test
+[19:35:42] @^helperblock: liquidnya, NB0-1MD-SLG has been added to the queue.
+
+[19:35:42] ~%?liquidnya: !add owo
+[19:35:42] @^helperblock: liquidnya, BW2-G2R-CMG has been added to the queue.

--- a/tests/chat-logs/logs/persistence.test.log
+++ b/tests/chat-logs/logs/persistence.test.log
@@ -1,0 +1,97 @@
+# "username" will decide which of the messages are from the bot
+settings {"username":"helperblock","password":"oauth:test","channel":"liquidnya","max_size":50,"level_timeout":10,"level_selection":[],"message_cooldown":5, "start_open": true}
+# restart to start queue open (reload settings)
+restart
+# chatters 
+chatters {"_links":{},"chatter_count":4,"chatters":{"broadcaster":["liquidnya"],"vips":[],"moderators":["furretwalkbot","streamelements"],"staff":[],"admins":[],"global_mods":[],"viewers":["viewerlevels"]}}
+# chatty chat log
+# ~ broadcaster
+# @ moderator
+# % subscriber
+
+# set test timer accuracy to 1 minute to accuratly test the weight
+accuracy 60000
+
+[12:12:28] ~%?liquidnya: !add BW2-G2R-CMG
+[12:12:29] @^helperblock: liquidnya, BW2-G2R-CMG has been added to the queue.
+[12:12:33] ~%?liquidnya: !list
+[12:12:34] @^helperblock: 1 online: (no current level), liquidnya... (0 offline)
+
+[12:15:33] ~%?liquidnya: !persistence off
+[12:15:34] @^helperblock: @liquidnya Deactivated automatic queue persistence.
+
+queue.json/currentLevel null
+queue.json/queue [{"code":"BW2-G2R-CMG","submitter":"liquidnya","username":"liquidnya"}]
+queue.json/waiting {"liquidnya":{"waitTime":3,"lastOnlineTime":"2022-04-21T12:14:34.000Z"}}
+
+# let one day pass
+[15:15:33] ~%?liquidnya: UwU
+[12:15:33] ~%?liquidnya: UwU
+
+# waiting did not change on disk!
+queue.json/waiting {"liquidnya":{"waitTime":3,"lastOnlineTime":"2022-04-21T12:14:34.000Z"}}
+
+# adding a level to the queue does not change anything on disk
+[12:15:34] @^FurretWalkBot: !add MY2-H2M-DSG
+[12:15:35] @^helperblock: FurretWalkBot, MY2-H2M-DSG has been added to the queue.
+queue.json/currentLevel null
+queue.json/queue [{"code":"BW2-G2R-CMG","submitter":"liquidnya","username":"liquidnya"}]
+queue.json/waiting {"liquidnya":{"waitTime":3,"lastOnlineTime":"2022-04-21T12:14:34.000Z"}}
+[12:15:36] ~%?liquidnya: !remove @FurretWalkBot
+[12:15:36] @^helperblock: @FurretWalkBot's level has been removed from the queue.
+queue.json/currentLevel null
+queue.json/queue [{"code":"BW2-G2R-CMG","submitter":"liquidnya","username":"liquidnya"}]
+queue.json/waiting {"liquidnya":{"waitTime":3,"lastOnlineTime":"2022-04-21T12:14:34.000Z"}}
+
+# manually persist
+
+# first make it fail
+fs-fail writeSync
+
+[12:15:37] ~%?liquidnya: !persistence save
+[12:15:38] @^helperblock: @liquidnya Error while persisting queue state, see logs.
+
+# still old save file
+queue.json/currentLevel null
+queue.json/queue [{"code":"BW2-G2R-CMG","submitter":"liquidnya","username":"liquidnya"}]
+queue.json/waiting {"liquidnya":{"waitTime":3,"lastOnlineTime":"2022-04-21T12:14:34.000Z"}}
+
+# now actually save it
+[12:15:38] ~%?liquidnya: !persistence save
+[12:15:39] @^helperblock: @liquidnya Successfully persisted the queue state.
+queue.json/currentLevel null
+queue.json/queue [{"code":"BW2-G2R-CMG","submitter":"liquidnya","username":"liquidnya"}]
+queue.json/waiting {"liquidnya":{"waitTime":1443,"lastOnlineTime":"2022-04-22T12:15:33.000Z"},"furretwalkbot":{"waitTime":1,"lastOnlineTime":"2022-04-22T12:15:34.000Z"}}
+
+# now override it with changes
+
+save:data/queue.json {"version":"2.0","currentLevel":{"code":"BW2-G2R-CMG","submitter":"liquidnya","username":"liquidnya"},"queue":[],"waiting":{}}
+
+[12:15:40] ~%?liquidnya: !list
+[12:15:44] @^helperblock: 1 online: (no current level), liquidnya... (0 offline)
+
+[12:15:44] ~%?liquidnya: !current
+[12:15:45] @^helperblock: We're not playing a level right now!
+
+[12:15:48] ~%?liquidnya: !persistence load
+[12:15:49] @^helperblock: @liquidnya Reloaded queue state from disk.
+
+[12:15:50] ~%?liquidnya: !list
+[12:15:51] @^helperblock: 1 online: liquidnya (current)... (0 offline)
+
+[12:19:17] ~%?liquidnya: !current
+[12:19:18] @^helperblock: Currently playing BW2-G2R-CMG submitted by liquidnya.
+
+# autosave is still off -> same file
+queue.json {"version":"2.0","currentLevel":{"code":"BW2-G2R-CMG","submitter":"liquidnya","username":"liquidnya"},"queue":[],"waiting":{}}
+
+[12:19:27] ~%?liquidnya: !persistence on
+[12:19:28] @^helperblock: @liquidnya Activated automatic queue persistence.
+
+[12:19:28] @^FurretWalkBot: !add MY2-H2M-DSG
+[12:19:28] @^helperblock: FurretWalkBot, MY2-H2M-DSG has been added to the queue.
+
+# it was automatically saved
+queue.json/currentLevel {"code":"BW2-G2R-CMG","submitter":"liquidnya","username":"liquidnya"}
+queue.json/queue [{"code":"MY2-H2M-DSG","submitter":"FurretWalkBot","username":"furretwalkbot"}]
+queue.json/waiting {"furretwalkbot":{"waitTime":1,"lastOnlineTime":"2022-04-22T12:19:28.000Z"}}


### PR DESCRIPTION
This fixes  #33.

### Custom Codes
Custom codes are currently broken in `master` in the sense that previously saved custom codes (saved before commit `9a178605c5960f82e91fdc557ba8d29965ce6eec`) will not work properly and also newly added custom codes will be saved in upper case.
For example:
A custom code previously saved as `Test` will not work.
A custom code `HahaCat` will be saved as `HAHACAT` and be listed as `HAHACAT` by using `!customcodes`.
This fix will save custom codes as-is and still allow adding a level with a custom code to the queue ignoring the case.
E.g. `!add HAHAcat` will work when there is a custom code named `HahaCat`.
This PR also adds test cases testing this behaviour, see `tests/chat-logs/logs/custom-codes.test.log`.
Also adds a `!customcode load` command to reload the `./customCodes.json` file into memory.

### !restore command
This PR also repairs the `!restore` command by removing it, and adding a new `!persistence` command which gives control over how and if data is loaded/saved. See updated `README.md` for a description of how it works.